### PR TITLE
Explicit Definition of Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ Do you have more questions (❓)? Let's move to [FAQ](#%EF%B8%8F-faq).
 
 For running `vercel dev` properly, you need to have PHP installed on your computer, [learn more](errors/now-dev-no-local-php.md).
 But it's PHP and as you know PHP has built-in development server. It works out of box.
+
+If you have some deployement errors, please check this [link](https://github.com/vercel-community/php/issues/504)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
         "dev": "vite",
         "build": "vite build"
     },
+    "engines": {
+        "node": "18.x"
+    },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.2",
         "alpinejs": "^3.4.2",


### PR DESCRIPTION
**For those who get this error:**
```
php: error while loading shared libraries: libssl.so.10: cannot open shared object file: No such file or directory
Error: Exited with 127
    at ChildProcess.<anonymous> (/vercel/path0/.vercel/builders/node_modules/vercel-php/dist/utils.js:182:24)
    at ChildProcess.emit (node:events:518:28)
    at ChildProcess.emit (node:domain:488:12)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12)
Error: Command "vercel build" exited with 1
Command "vercel build" exited with 1
```
## Add to your `package.json`
```
"engines": {
        "node": "18.x"
    },
```
